### PR TITLE
Update to InRule v5.8.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
     - name: Checkout Source
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
@@ -33,7 +33,7 @@ jobs:
 
     - name: Upload artifacts
       if: matrix.inrule == '5.6.0'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: artifacts
         path: artifacts
@@ -49,7 +49,7 @@ jobs:
 
     steps:
     - name: Checkout Source
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
     
@@ -74,7 +74,7 @@ jobs:
         fetch-depth: 0
 
     - name: Download artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: artifacts
         path: artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        inrule: [5.2.0, 5.3.1, 5.4.3, 5.5.1, 5.6.0, 5.7.3]
+        inrule: [5.2.0, 5.3.1, 5.4.3, 5.5.1, 5.6.0, 5.7.3, 5.8.1]
 
     steps:
     - name: Checkout Source
@@ -32,7 +32,7 @@ jobs:
       run: ./build.ps1 --target PublishAuthoringArtifacts --skip Clean
 
     - name: Upload artifacts
-      if: matrix.inrule == '5.2.0'
+      if: matrix.inrule == '5.6.0'
       uses: actions/upload-artifact@v3
       with:
         name: artifacts
@@ -45,7 +45,7 @@ jobs:
 
     strategy:
       matrix:
-        inrule: [5.2.0, 5.3.1, 5.4.3, 5.5.1, 5.6.0, 5.7.3]
+        inrule: [5.2.0, 5.3.1, 5.4.3, 5.5.1, 5.6.0, 5.7.3, 5.8.1]
 
     steps:
     - name: Checkout Source

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -1,73 +1,70 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "Build Schema",
-  "$ref": "#/definitions/build",
   "definitions": {
-    "build": {
-      "type": "object",
+    "Host": {
+      "type": "string",
+      "enum": [
+        "AppVeyor",
+        "AzurePipelines",
+        "Bamboo",
+        "Bitbucket",
+        "Bitrise",
+        "GitHubActions",
+        "GitLab",
+        "Jenkins",
+        "Rider",
+        "SpaceAutomation",
+        "TeamCity",
+        "Terminal",
+        "TravisCI",
+        "VisualStudio",
+        "VSCode"
+      ]
+    },
+    "ExecutableTarget": {
+      "type": "string",
+      "enum": [
+        "Clean",
+        "CompileAuthoring",
+        "CompileSdk",
+        "Default",
+        "DeployToIrAuthor",
+        "PublishAuthoringArtifacts",
+        "PublishSdkArtifacts",
+        "PublishToGitHub",
+        "PublishToNuGetFeed",
+        "RestoreAuthoring",
+        "RestoreSdk",
+        "TestSdk"
+      ]
+    },
+    "Verbosity": {
+      "type": "string",
+      "description": "",
+      "enum": [
+        "Verbose",
+        "Normal",
+        "Minimal",
+        "Quiet"
+      ]
+    },
+    "NukeBuild": {
       "properties": {
-        "Configuration": {
-          "type": "string",
-          "description": "Configuration to build. Default is 'Debug' (local) or 'Release' (server)",
-          "enum": [
-            "Debug",
-            "Release"
-          ]
-        },
         "Continue": {
           "type": "boolean",
           "description": "Indicates to continue a previously failed build attempt"
-        },
-        "GitHubAccessToken": {
-          "type": "string",
-          "description": "GitHub access token used for creating a new or updating an existing release",
-          "default": "Secrets must be entered via 'nuke :secrets [profile]'"
-        },
-        "GitHubRepository": {
-          "type": "string",
-          "description": "GitHub repository owner and name used for creating a new or updating an existing release. For example: 'stevenkuhn/InRuleGitStorage'"
         },
         "Help": {
           "type": "boolean",
           "description": "Shows the help text for this build assembly"
         },
         "Host": {
-          "type": "string",
           "description": "Host for execution. Default is 'automatic'",
-          "enum": [
-            "AppVeyor",
-            "AzurePipelines",
-            "Bamboo",
-            "Bitbucket",
-            "Bitrise",
-            "GitHubActions",
-            "GitLab",
-            "Jenkins",
-            "Rider",
-            "SpaceAutomation",
-            "TeamCity",
-            "Terminal",
-            "TravisCI",
-            "VisualStudio",
-            "VSCode"
-          ]
-        },
-        "inrule-version": {
-          "type": "string",
-          "description": "Version of the InRule Repository SDK use. Default is 5.2.0"
+          "$ref": "#/definitions/Host"
         },
         "NoLogo": {
           "type": "boolean",
           "description": "Disables displaying the NUKE logo"
-        },
-        "NuGetApiKey": {
-          "type": "string",
-          "description": "NuGet API key used to pushing the Sdk NuGet package",
-          "default": "Secrets must be entered via 'nuke :secrets [profile]'"
-        },
-        "NuGetSource": {
-          "type": "string",
-          "description": "NuGet source used for pushing the Sdk NuGet package. Default is NuGet.org"
         },
         "Partition": {
           "type": "string",
@@ -92,59 +89,64 @@
           "type": "array",
           "description": "List of targets to be skipped. Empty list skips all dependencies",
           "items": {
-            "type": "string",
-            "enum": [
-              "Clean",
-              "CompileAuthoring",
-              "CompileSdk",
-              "Default",
-              "DeployToIrAuthor",
-              "PublishAuthoringArtifacts",
-              "PublishSdkArtifacts",
-              "PublishToGitHub",
-              "PublishToNuGetFeed",
-              "RestoreAuthoring",
-              "RestoreSdk",
-              "TestSdk"
-            ]
+            "$ref": "#/definitions/ExecutableTarget"
           }
-        },
-        "Solution": {
-          "type": "string",
-          "description": "Path to a solution file that is automatically loaded"
         },
         "Target": {
           "type": "array",
           "description": "List of targets to be invoked. Default is '{default_target}'",
           "items": {
-            "type": "string",
-            "enum": [
-              "Clean",
-              "CompileAuthoring",
-              "CompileSdk",
-              "Default",
-              "DeployToIrAuthor",
-              "PublishAuthoringArtifacts",
-              "PublishSdkArtifacts",
-              "PublishToGitHub",
-              "PublishToNuGetFeed",
-              "RestoreAuthoring",
-              "RestoreSdk",
-              "TestSdk"
-            ]
+            "$ref": "#/definitions/ExecutableTarget"
           }
         },
         "Verbosity": {
-          "type": "string",
           "description": "Logging verbosity during build execution. Default is 'Normal'",
-          "enum": [
-            "Minimal",
-            "Normal",
-            "Quiet",
-            "Verbose"
-          ]
+          "$ref": "#/definitions/Verbosity"
         }
       }
     }
-  }
+  },
+  "allOf": [
+    {
+      "properties": {
+        "Configuration": {
+          "type": "string",
+          "description": "Configuration to build. Default is 'Debug' (local) or 'Release' (server)",
+          "enum": [
+            "Debug",
+            "Release"
+          ]
+        },
+        "GitHubAccessToken": {
+          "type": "string",
+          "description": "GitHub access token used for creating a new or updating an existing release",
+          "default": "Secrets must be entered via 'nuke :secrets [profile]'"
+        },
+        "GitHubRepository": {
+          "type": "string",
+          "description": "GitHub repository owner and name used for creating a new or updating an existing release. For example: 'stevenkuhn/InRuleGitStorage'"
+        },
+        "inrule-version": {
+          "type": "string",
+          "description": "Version of the InRule Repository SDK use. Default is 5.6.0"
+        },
+        "NuGetApiKey": {
+          "type": "string",
+          "description": "NuGet API key used to pushing the Sdk NuGet package",
+          "default": "Secrets must be entered via 'nuke :secrets [profile]'"
+        },
+        "NuGetSource": {
+          "type": "string",
+          "description": "NuGet source used for pushing the Sdk NuGet package. Default is NuGet.org"
+        },
+        "Solution": {
+          "type": "string",
+          "description": "Path to a solution file that is automatically loaded"
+        }
+      }
+    },
+    {
+      "$ref": "#/definitions/NukeBuild"
+    }
+  ]
 }

--- a/Sknet.InRuleGitStorage.v3.ncrunchsolution
+++ b/Sknet.InRuleGitStorage.v3.ncrunchsolution
@@ -1,6 +1,8 @@
 ﻿<SolutionConfiguration>
   <Settings>
     <AllowParallelTestExecution>True</AllowParallelTestExecution>
+    <EnableRDI>True</EnableRDI>
+    <RdiConfigured>True</RdiConfigured>
     <SolutionConfigured>True</SolutionConfigured>
   </Settings>
 </SolutionConfiguration>

--- a/build.ps1
+++ b/build.ps1
@@ -18,14 +18,10 @@ $TempDirectory = "$PSScriptRoot\\.nuke\temp"
 
 $DotNetGlobalFile = "$PSScriptRoot\\global.json"
 $DotNetInstallUrl = "https://dot.net/v1/dotnet-install.ps1"
-$DotNetChannel = "Current"
+$DotNetChannel = "STS"
 
-$env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE = 1
 $env:DOTNET_CLI_TELEMETRY_OPTOUT = 1
-$env:DOTNET_MULTILEVEL_LOOKUP = 0
-
 $env:DOTNET_NOLOGO = 1
-$env:NUKE_TELEMETRY_OPTOUT = 1
 
 ###########################################################################
 # EXECUTION
@@ -64,9 +60,15 @@ else {
         ExecSafe { & powershell $DotNetInstallFile -InstallDir $DotNetDirectory -Version $DotNetVersion -NoPath }
     }
     $env:DOTNET_EXE = "$DotNetDirectory\dotnet.exe"
+    $env:PATH = "$DotNetDirectory;$env:PATH"
 }
 
-Write-Output "Microsoft (R) .NET Core SDK version $(& $env:DOTNET_EXE --version)"
+Write-Output "Microsoft (R) .NET SDK version $(& $env:DOTNET_EXE --version)"
+
+if (Test-Path env:NUKE_ENTERPRISE_TOKEN) {
+    & $env:DOTNET_EXE nuget remove source "nuke-enterprise" > $null
+    & $env:DOTNET_EXE nuget add source "https://f.feedz.io/nuke/enterprise/nuget" --name "nuke-enterprise" --username "PAT" --password $env:NUKE_ENTERPRISE_TOKEN > $null
+}
 
 ExecSafe { & $env:DOTNET_EXE build $BuildProjectFile /nodeReuse:false /p:UseSharedCompilation=false -nologo -clp:NoSummary --verbosity quiet }
 ExecSafe { & $env:DOTNET_EXE run --project $BuildProjectFile --no-build -- $BuildArguments }

--- a/build.sh
+++ b/build.sh
@@ -14,14 +14,10 @@ TEMP_DIRECTORY="$SCRIPT_DIR//.nuke/temp"
 
 DOTNET_GLOBAL_FILE="$SCRIPT_DIR//global.json"
 DOTNET_INSTALL_URL="https://dot.net/v1/dotnet-install.sh"
-DOTNET_CHANNEL="Current"
+DOTNET_CHANNEL="STS"
 
 export DOTNET_CLI_TELEMETRY_OPTOUT=1
-export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
-export DOTNET_MULTILEVEL_LOOKUP=0
-
 export DOTNET_NOLOGO=1
-export NUKE_TELEMETRY_OPTOUT=1
 
 ###########################################################################
 # EXECUTION
@@ -57,9 +53,15 @@ else
         "$DOTNET_INSTALL_FILE" --install-dir "$DOTNET_DIRECTORY" --version "$DOTNET_VERSION" --no-path
     fi
     export DOTNET_EXE="$DOTNET_DIRECTORY/dotnet"
+    export PATH="$DOTNET_DIRECTORY:$PATH"
 fi
 
-echo "Microsoft (R) .NET Core SDK version $("$DOTNET_EXE" --version)"
+echo "Microsoft (R) .NET SDK version $("$DOTNET_EXE" --version)"
+
+if [[ ! -z ${NUKE_ENTERPRISE_TOKEN+x} && "$NUKE_ENTERPRISE_TOKEN" != "" ]]; then
+    "$DOTNET_EXE" nuget remove source "nuke-enterprise" &>/dev/null || true
+    "$DOTNET_EXE" nuget add source "https://f.feedz.io/nuke/enterprise/nuget" --name "nuke-enterprise" --username "PAT" --password "$NUKE_ENTERPRISE_TOKEN" --store-password-in-clear-text &>/dev/null || true
+fi
 
 "$DOTNET_EXE" build "$BUILD_PROJECT_FILE" /nodeReuse:false /p:UseSharedCompilation=false -nologo -clp:NoSummary --verbosity quiet
 "$DOTNET_EXE" run --project "$BUILD_PROJECT_FILE" --no-build -- "$@"

--- a/build/.editorconfig
+++ b/build/.editorconfig
@@ -9,3 +9,51 @@ csharp_style_expression_bodied_methods = true:silent
 csharp_style_expression_bodied_properties = true:warning
 csharp_style_expression_bodied_indexers = true:warning
 csharp_style_expression_bodied_accessors = true:warning
+
+[*.{cs,vb}]
+#### Naming styles ####
+
+# Naming rules
+
+dotnet_naming_rule.interface_should_be_begins_with_i.severity = suggestion
+dotnet_naming_rule.interface_should_be_begins_with_i.symbols = interface
+dotnet_naming_rule.interface_should_be_begins_with_i.style = begins_with_i
+
+dotnet_naming_rule.types_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.types_should_be_pascal_case.symbols = types
+dotnet_naming_rule.types_should_be_pascal_case.style = pascal_case
+
+dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
+dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
+
+# Symbol specifications
+
+dotnet_naming_symbols.interface.applicable_kinds = interface
+dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.interface.required_modifiers = 
+
+dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
+dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.types.required_modifiers = 
+
+dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
+dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.non_field_members.required_modifiers = 
+
+# Naming styles
+
+dotnet_naming_style.begins_with_i.required_prefix = I
+dotnet_naming_style.begins_with_i.required_suffix = 
+dotnet_naming_style.begins_with_i.word_separator = 
+dotnet_naming_style.begins_with_i.capitalization = pascal_case
+
+dotnet_naming_style.pascal_case.required_prefix = 
+dotnet_naming_style.pascal_case.required_suffix = 
+dotnet_naming_style.pascal_case.word_separator = 
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+
+dotnet_naming_style.pascal_case.required_prefix = 
+dotnet_naming_style.pascal_case.required_suffix = 
+dotnet_naming_style.pascal_case.word_separator = 
+dotnet_naming_style.pascal_case.capitalization = pascal_case

--- a/build/Build.csproj
+++ b/build/Build.csproj
@@ -2,12 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace></RootNamespace>
-    <NoWarn>CS0649;CS0169</NoWarn>
+    <NoWarn>CS0649;CS0169;CA1050;CA1822;CA2211;IDE1006</NoWarn>
     <NukeRootDirectory>..</NukeRootDirectory>
     <NukeScriptDirectory>..</NukeScriptDirectory>
     <NukeTelemetryVersion>1</NukeTelemetryVersion>
+    <IsPackable>false</IsPackable>
     <NUKE_TELEMETRY_OPTOUT>1</NUKE_TELEMETRY_OPTOUT>
 
     <Authors>Steven Kuhn</Authors>
@@ -20,7 +21,7 @@
 
   <ItemGroup>
     <PackageDownload Include="GitVersion.Tool" Version="[5.8.1]" />
-    <PackageReference Include="Nuke.Common" Version="6.3.0" />
+    <PackageReference Include="Nuke.Common" Version="9.0.4" />
   </ItemGroup>
 
 </Project>

--- a/build/GlobalUsings.cs
+++ b/build/GlobalUsings.cs
@@ -19,8 +19,6 @@ global using Nuke.Common.Tools.NuGet;
 global using Nuke.Common.Utilities.Collections;
 
 global using static Nuke.Common.EnvironmentInfo;
-global using static Nuke.Common.IO.CompressionTasks;
-global using static Nuke.Common.IO.FileSystemTasks;
 global using static Nuke.Common.IO.PathConstruction;
 global using static Nuke.Common.Tools.DotNet.DotNetTasks;
 global using static Nuke.Common.Tools.NuGet.NuGetTasks;

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.100",
+    "version": "8.0.310",
     "rollForward": "latestMinor"
   }
 }

--- a/src/Sknet.InRuleGitStorage.AuthoringExtension/Sknet.InRuleGitStorage.AuthoringExtension.csproj
+++ b/src/Sknet.InRuleGitStorage.AuthoringExtension/Sknet.InRuleGitStorage.AuthoringExtension.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="InRule.Authoring.SDK" Version="5.2.0" />
+    <PackageReference Include="InRule.Authoring.SDK" Version="5.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Sknet.InRuleGitStorage/Extensions/TypeExtensions.cs
+++ b/src/Sknet.InRuleGitStorage/Extensions/TypeExtensions.cs
@@ -2,11 +2,11 @@
 
 internal static class TypeExtensions
 {
-    public static T GetCustomAttribute<T>(this Type type, bool inherit)
+    public static T? GetCustomAttribute<T>(this Type type, bool inherit)
     {
         if (type == null) throw new ArgumentNullException(nameof(type));
 
-        return (T)type.GetCustomAttributes(typeof(T), inherit).SingleOrDefault();
+        return (T?)type.GetCustomAttributes(typeof(T), inherit).SingleOrDefault();
     }
 
     public static string GetXmlTypeName(this Type type)

--- a/src/Sknet.InRuleGitStorage/InRuleGitSerializer.cs
+++ b/src/Sknet.InRuleGitStorage/InRuleGitSerializer.cs
@@ -274,8 +274,8 @@ internal class InRuleGitSerializer : IInRuleGitSerializer
             var blob = _repository.ObjectDatabase.CreateBlob(def);
             treeDefinition.Add($"{def.Name}.xml", blob, Mode.NonExecutableFile);
 
-            var defPointer = (RuleRepositoryDefBase)Activator.CreateInstance(def.GetType());
-            defPointer.Guid = def.Guid;
+            var defPointer = (RuleRepositoryDefBase)Activator.CreateInstance(def.GetType())!;
+            defPointer!.Guid = def.Guid;
             defPointer.Name = def.Guid.ToString();
             defs[i] = defPointer;
         }
@@ -301,8 +301,8 @@ internal class InRuleGitSerializer : IInRuleGitSerializer
             var tree = SerializeDefToTree(def);
             treeDefinition.Add($"{def.Name}", tree);
 
-            var defPointer = (RuleRepositoryDefBase)Activator.CreateInstance(def.GetType());
-            defPointer.Guid = def.Guid;
+            var defPointer = (RuleRepositoryDefBase)Activator.CreateInstance(def.GetType())!;
+            defPointer!.Guid = def.Guid;
             defPointer.Name = def.Guid.ToString();
             defs[i] = defPointer;
         }
@@ -441,13 +441,13 @@ internal class InRuleGitSerializer : IInRuleGitSerializer
         {
             xmlStream = def.GetXmlStream();
 
-            using (SHA1Managed sha1 = new SHA1Managed())
+            using (SHA1 sha1 = SHA1.Create())
             {
                 sha1Hash = new ObjectId(sha1.ComputeHash(xmlStream)).Sha;
                 xmlStream.Position = 0;
             }
 
-            if (DefHashToTreeShaLookup.TryGetValue(sha1Hash, out string treeSha))
+            if (DefHashToTreeShaLookup.TryGetValue(sha1Hash, out var treeSha))
             {
                 var tree = _repository.Lookup<Tree>(treeSha);
                 return tree;

--- a/src/Sknet.InRuleGitStorage/Sknet.InRuleGitStorage.csproj
+++ b/src/Sknet.InRuleGitStorage/Sknet.InRuleGitStorage.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461;net472</TargetFrameworks>
+    <TargetFrameworks>net8.0;net472</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>10</LangVersion>
     <Nullable>enable</Nullable>
@@ -44,7 +44,7 @@
 
   <ItemGroup>
     <PackageReference Include="InRule.Repository" Version="5.2.0" />
-    <PackageReference Include="LibGit2Sharp" Version="0.27.0-preview-0182" />
+    <PackageReference Include="LibGit2Sharp" Version="0.31.0" />
   </ItemGroup>
 
 </Project>

--- a/test/Sknet.InRuleGitStorage.Tests/InRuleGitRepositoryTests/SerializationTests.cs
+++ b/test/Sknet.InRuleGitStorage.Tests/InRuleGitRepositoryTests/SerializationTests.cs
@@ -1,4 +1,6 @@
-﻿namespace Sknet.InRuleGitStorage.Tests.InRuleGitRepositoryTests;
+﻿using System.Text.RegularExpressions;
+
+namespace Sknet.InRuleGitStorage.Tests.InRuleGitRepositoryTests;
 
 public class SerializationTests : IDisposable
 {
@@ -44,6 +46,11 @@ public class SerializationTests : IDisposable
         // Assert
         var expectedXml = RuleRepositoryDefBase.GetXml(ruleApp);
         var resultXml = RuleRepositoryDefBase.GetXml(result);
+
+        // HACK: Replace the Guid in <DefaultSubRulesRoot /> with an Empty guid because it changes on every call to GetXml()
+        string pattern = @"(<DefaultSubRulesRoot\s+[^>]*Guid="")[^""]*("")";
+        expectedXml = Regex.Replace(expectedXml, pattern, $"$1{Guid.Empty}$2");
+        resultXml = Regex.Replace(resultXml, pattern, $"$1{Guid.Empty}$2");
 
         Assert.Equal(expectedXml, resultXml);
     }

--- a/test/Sknet.InRuleGitStorage.Tests/Sknet.InRuleGitStorage.Tests.csproj
+++ b/test/Sknet.InRuleGitStorage.Tests/Sknet.InRuleGitStorage.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net8.0;net472</TargetFrameworks>
@@ -26,9 +26,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" Condition="'$(TargetFramework)' != 'net461'">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2" Condition="'$(TargetFramework)' != 'net461'">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
@@ -36,7 +36,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.2.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/test/Sknet.InRuleGitStorage.Tests/Sknet.InRuleGitStorage.Tests.csproj
+++ b/test/Sknet.InRuleGitStorage.Tests/Sknet.InRuleGitStorage.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net461;net472</TargetFrameworks>
+    <TargetFrameworks>net8.0;net472</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>10</LangVersion>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
This updates the build and testing to include InRule v5.8.0. It also updates libgit2sharp to the latest version, which requires the bump in target frameworks to `net8.0` and `net472`.